### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -8,6 +8,9 @@ name: Scala Steward
 jobs:
   scala-steward:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     name: Scala Steward
     steps:
       - name: Launch Scala Steward


### PR DESCRIPTION
Potential fix for [https://github.com/freezingsaddles/freezing-teams/security/code-scanning/1](https://github.com/freezingsaddles/freezing-teams/security/code-scanning/1)

To fix this problem, add the `permissions` key specifying the minimal required privileges for the job. The `scala-steward` action needs to create and update pull requests, and possibly make changes to repository contents. A minimal starting point is to grant `contents: write` and `pull-requests: write` permissions either at the job level (inside `scala-steward` job under `jobs:`) or at the workflow root (affecting all jobs). Adding at the job level is best for least privilege. 

Edit `.github/workflows/scala-steward.yml` by adding the following block:

```yaml
permissions:
  contents: write
  pull-requests: write
```

Place this block at the same indentation level as `runs-on` (line 10), i.e. directly under the job (`scala-steward:`). No additional imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
